### PR TITLE
fix build.gradle for AndroidStudio 1.0.0

### DIFF
--- a/AndroidStudio/answers/assignments/fundamentals/1st/LayoutAssignment2/app/build.gradle
+++ b/AndroidStudio/answers/assignments/fundamentals/1st/LayoutAssignment2/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/answers/assignments/fundamentals/1st/LayoutAssignment2/build.gradle
+++ b/AndroidStudio/answers/assignments/fundamentals/1st/LayoutAssignment2/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/answers/assignments/fundamentals/1st/LayoutAssignment2/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/answers/assignments/fundamentals/1st/LayoutAssignment2/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/answers/assignments/fundamentals/1st/LayoutAssignment3/app/build.gradle
+++ b/AndroidStudio/answers/assignments/fundamentals/1st/LayoutAssignment3/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/answers/assignments/fundamentals/1st/LayoutAssignment3/build.gradle
+++ b/AndroidStudio/answers/assignments/fundamentals/1st/LayoutAssignment3/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/answers/assignments/fundamentals/1st/LayoutAssignment3/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/answers/assignments/fundamentals/1st/LayoutAssignment3/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/answers/practice/fundamentals/1st/FrameLayoutPractice/Practice1/app/build.gradle
+++ b/AndroidStudio/answers/practice/fundamentals/1st/FrameLayoutPractice/Practice1/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/answers/practice/fundamentals/1st/FrameLayoutPractice/Practice1/build.gradle
+++ b/AndroidStudio/answers/practice/fundamentals/1st/FrameLayoutPractice/Practice1/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/answers/practice/fundamentals/1st/FrameLayoutPractice/Practice1/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/answers/practice/fundamentals/1st/FrameLayoutPractice/Practice1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/answers/practice/fundamentals/1st/FrameLayoutPractice/Practice2/app/build.gradle
+++ b/AndroidStudio/answers/practice/fundamentals/1st/FrameLayoutPractice/Practice2/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/answers/practice/fundamentals/1st/FrameLayoutPractice/Practice2/build.gradle
+++ b/AndroidStudio/answers/practice/fundamentals/1st/FrameLayoutPractice/Practice2/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/answers/practice/fundamentals/1st/FrameLayoutPractice/Practice2/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/answers/practice/fundamentals/1st/FrameLayoutPractice/Practice2/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/answers/practice/fundamentals/1st/LinearLayoutPractice/Practice1/app/build.gradle
+++ b/AndroidStudio/answers/practice/fundamentals/1st/LinearLayoutPractice/Practice1/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/answers/practice/fundamentals/1st/LinearLayoutPractice/Practice1/build.gradle
+++ b/AndroidStudio/answers/practice/fundamentals/1st/LinearLayoutPractice/Practice1/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/answers/practice/fundamentals/1st/LinearLayoutPractice/Practice1/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/answers/practice/fundamentals/1st/LinearLayoutPractice/Practice1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/answers/practice/fundamentals/1st/LinearLayoutPractice/Practice2/app/build.gradle
+++ b/AndroidStudio/answers/practice/fundamentals/1st/LinearLayoutPractice/Practice2/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/answers/practice/fundamentals/1st/LinearLayoutPractice/Practice2/build.gradle
+++ b/AndroidStudio/answers/practice/fundamentals/1st/LinearLayoutPractice/Practice2/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/answers/practice/fundamentals/1st/LinearLayoutPractice/Practice2/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/answers/practice/fundamentals/1st/LinearLayoutPractice/Practice2/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/answers/practice/fundamentals/1st/RelativeLayoutPractice/Practice1/app/build.gradle
+++ b/AndroidStudio/answers/practice/fundamentals/1st/RelativeLayoutPractice/Practice1/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/answers/practice/fundamentals/1st/RelativeLayoutPractice/Practice1/build.gradle
+++ b/AndroidStudio/answers/practice/fundamentals/1st/RelativeLayoutPractice/Practice1/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/answers/practice/fundamentals/1st/RelativeLayoutPractice/Practice1/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/answers/practice/fundamentals/1st/RelativeLayoutPractice/Practice1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/answers/practice/fundamentals/1st/RelativeLayoutPractice/Practice2/app/build.gradle
+++ b/AndroidStudio/answers/practice/fundamentals/1st/RelativeLayoutPractice/Practice2/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/answers/practice/fundamentals/1st/RelativeLayoutPractice/Practice2/build.gradle
+++ b/AndroidStudio/answers/practice/fundamentals/1st/RelativeLayoutPractice/Practice2/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/answers/practice/fundamentals/1st/RelativeLayoutPractice/Practice2/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/answers/practice/fundamentals/1st/RelativeLayoutPractice/Practice2/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/answers/practice/fundamentals/1st/ScrollViewPractice/Practice1/app/build.gradle
+++ b/AndroidStudio/answers/practice/fundamentals/1st/ScrollViewPractice/Practice1/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/answers/practice/fundamentals/1st/ScrollViewPractice/Practice1/build.gradle
+++ b/AndroidStudio/answers/practice/fundamentals/1st/ScrollViewPractice/Practice1/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/answers/practice/fundamentals/1st/ScrollViewPractice/Practice1/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/answers/practice/fundamentals/1st/ScrollViewPractice/Practice1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/advanced/1st/DebugPractice/app/build.gradle
+++ b/AndroidStudio/practice/advanced/1st/DebugPractice/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/advanced/1st/DebugPractice/build.gradle
+++ b/AndroidStudio/practice/advanced/1st/DebugPractice/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/advanced/1st/DebugPractice/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/advanced/1st/DebugPractice/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/advanced/3rd/DialogPractice/app/build.gradle
+++ b/AndroidStudio/practice/advanced/3rd/DialogPractice/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/advanced/3rd/DialogPractice/build.gradle
+++ b/AndroidStudio/practice/advanced/3rd/DialogPractice/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/advanced/3rd/DialogPractice/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/advanced/3rd/DialogPractice/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/advanced/3rd/DialogPractice2/app/build.gradle
+++ b/AndroidStudio/practice/advanced/3rd/DialogPractice2/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/advanced/3rd/DialogPractice2/build.gradle
+++ b/AndroidStudio/practice/advanced/3rd/DialogPractice2/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/advanced/3rd/DialogPractice2/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/advanced/3rd/DialogPractice2/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/advanced/3rd/IncludePractice/app/build.gradle
+++ b/AndroidStudio/practice/advanced/3rd/IncludePractice/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/advanced/3rd/IncludePractice/build.gradle
+++ b/AndroidStudio/practice/advanced/3rd/IncludePractice/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/advanced/3rd/IncludePractice/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/advanced/3rd/IncludePractice/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/advanced/3rd/PreferencePractice/app/build.gradle
+++ b/AndroidStudio/practice/advanced/3rd/PreferencePractice/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/advanced/3rd/PreferencePractice/build.gradle
+++ b/AndroidStudio/practice/advanced/3rd/PreferencePractice/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/advanced/3rd/PreferencePractice/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/advanced/3rd/PreferencePractice/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/10th/SQLitePractice/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/10th/SQLitePractice/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/10th/SQLitePractice/build.gradle
+++ b/AndroidStudio/practice/fundamentals/10th/SQLitePractice/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/10th/SQLitePractice/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/10th/SQLitePractice/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/1st/FrameLayoutPractice/Practice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/FrameLayoutPractice/Practice1/app/build.gradle
@@ -1,8 +1,8 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/1st/FrameLayoutPractice/Practice1/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/FrameLayoutPractice/Practice1/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/1st/FrameLayoutPractice/Practice1/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/1st/FrameLayoutPractice/Practice1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/1st/FrameLayoutPractice/Practice2/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/FrameLayoutPractice/Practice2/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/1st/FrameLayoutPractice/Practice2/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/FrameLayoutPractice/Practice2/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/1st/FrameLayoutPractice/Practice2/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/1st/FrameLayoutPractice/Practice2/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/1st/LinearLayoutPractice/Practice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/LinearLayoutPractice/Practice1/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/1st/LinearLayoutPractice/Practice1/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/LinearLayoutPractice/Practice1/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/1st/LinearLayoutPractice/Practice1/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/1st/LinearLayoutPractice/Practice1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/1st/LinearLayoutPractice/Practice2/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/LinearLayoutPractice/Practice2/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/1st/LinearLayoutPractice/Practice2/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/LinearLayoutPractice/Practice2/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/1st/LinearLayoutPractice/Practice2/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/1st/LinearLayoutPractice/Practice2/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/1st/RelativeLayoutPractice/Practice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/RelativeLayoutPractice/Practice1/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/1st/RelativeLayoutPractice/Practice1/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/RelativeLayoutPractice/Practice1/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/1st/RelativeLayoutPractice/Practice1/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/1st/RelativeLayoutPractice/Practice1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/1st/RelativeLayoutPractice/Practice2/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/RelativeLayoutPractice/Practice2/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/1st/RelativeLayoutPractice/Practice2/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/RelativeLayoutPractice/Practice2/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/1st/RelativeLayoutPractice/Practice2/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/1st/RelativeLayoutPractice/Practice2/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/1st/ScrollViewPractice/Practice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/ScrollViewPractice/Practice1/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/1st/ScrollViewPractice/Practice1/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/ScrollViewPractice/Practice1/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/1st/ScrollViewPractice/Practice1/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/1st/ScrollViewPractice/Practice1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/2nd/ActivityPractice/Practice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/2nd/ActivityPractice/Practice1/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/2nd/ActivityPractice/Practice1/build.gradle
+++ b/AndroidStudio/practice/fundamentals/2nd/ActivityPractice/Practice1/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/2nd/ActivityPractice/Practice1/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/2nd/ActivityPractice/Practice1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/2nd/ActivityPractice/Practice2/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/2nd/ActivityPractice/Practice2/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/2nd/ActivityPractice/Practice2/build.gradle
+++ b/AndroidStudio/practice/fundamentals/2nd/ActivityPractice/Practice2/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/2nd/ActivityPractice/Practice2/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/2nd/ActivityPractice/Practice2/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/2nd/FragmentPractice/Practice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/2nd/FragmentPractice/Practice1/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/2nd/FragmentPractice/Practice1/build.gradle
+++ b/AndroidStudio/practice/fundamentals/2nd/FragmentPractice/Practice1/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/2nd/FragmentPractice/Practice1/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/2nd/FragmentPractice/Practice1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/2nd/FragmentPractice/Practice2/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/2nd/FragmentPractice/Practice2/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/2nd/FragmentPractice/Practice2/build.gradle
+++ b/AndroidStudio/practice/fundamentals/2nd/FragmentPractice/Practice2/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/2nd/FragmentPractice/Practice2/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/2nd/FragmentPractice/Practice2/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/3rd/AnimationResourcePractice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/3rd/AnimationResourcePractice1/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/3rd/AnimationResourcePractice1/build.gradle
+++ b/AndroidStudio/practice/fundamentals/3rd/AnimationResourcePractice1/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/3rd/AnimationResourcePractice1/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/3rd/AnimationResourcePractice1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/3rd/DrawableResourcePractice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/3rd/DrawableResourcePractice1/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/3rd/DrawableResourcePractice1/build.gradle
+++ b/AndroidStudio/practice/fundamentals/3rd/DrawableResourcePractice1/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/3rd/DrawableResourcePractice1/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/3rd/DrawableResourcePractice1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/3rd/StringResourcePractice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/3rd/StringResourcePractice1/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/3rd/StringResourcePractice1/build.gradle
+++ b/AndroidStudio/practice/fundamentals/3rd/StringResourcePractice1/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/3rd/StringResourcePractice1/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/3rd/StringResourcePractice1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/3rd/StringResourcePractice2/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/3rd/StringResourcePractice2/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/3rd/StringResourcePractice2/build.gradle
+++ b/AndroidStudio/practice/fundamentals/3rd/StringResourcePractice2/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/3rd/StringResourcePractice2/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/3rd/StringResourcePractice2/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/4th/IntentPractice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/4th/IntentPractice1/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/4th/IntentPractice1/build.gradle
+++ b/AndroidStudio/practice/fundamentals/4th/IntentPractice1/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/4th/IntentPractice1/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/4th/IntentPractice1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/4th/IntentPractice2/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/4th/IntentPractice2/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/4th/IntentPractice2/build.gradle
+++ b/AndroidStudio/practice/fundamentals/4th/IntentPractice2/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/4th/IntentPractice2/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/4th/IntentPractice2/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/4th/NotificationPractice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/4th/NotificationPractice1/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/4th/NotificationPractice1/build.gradle
+++ b/AndroidStudio/practice/fundamentals/4th/NotificationPractice1/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/4th/NotificationPractice1/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/4th/NotificationPractice1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/5th/ActionBarPractice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/5th/ActionBarPractice1/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/5th/ActionBarPractice1/build.gradle
+++ b/AndroidStudio/practice/fundamentals/5th/ActionBarPractice1/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/5th/ActionBarPractice1/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/5th/ActionBarPractice1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/5th/InteractionCallbackPractice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/5th/InteractionCallbackPractice1/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/5th/InteractionCallbackPractice1/build.gradle
+++ b/AndroidStudio/practice/fundamentals/5th/InteractionCallbackPractice1/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/5th/InteractionCallbackPractice1/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/5th/InteractionCallbackPractice1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/6th/ListViewPractice/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/6th/ListViewPractice/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/6th/ListViewPractice/build.gradle
+++ b/AndroidStudio/practice/fundamentals/6th/ListViewPractice/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/6th/ListViewPractice/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/6th/ListViewPractice/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/7th/SerializablePractice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/7th/SerializablePractice1/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/7th/SerializablePractice1/build.gradle
+++ b/AndroidStudio/practice/fundamentals/7th/SerializablePractice1/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/7th/SerializablePractice1/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/7th/SerializablePractice1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/7th/SharedPreferencesPractice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/7th/SharedPreferencesPractice1/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/7th/SharedPreferencesPractice1/build.gradle
+++ b/AndroidStudio/practice/fundamentals/7th/SharedPreferencesPractice1/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/7th/SharedPreferencesPractice1/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/7th/SharedPreferencesPractice1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/7th/StoragePractice/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/7th/StoragePractice/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/7th/StoragePractice/build.gradle
+++ b/AndroidStudio/practice/fundamentals/7th/StoragePractice/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/7th/StoragePractice/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/7th/StoragePractice/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/9th/NetworkPractice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/9th/NetworkPractice1/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 9
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/9th/NetworkPractice1/build.gradle
+++ b/AndroidStudio/practice/fundamentals/9th/NetworkPractice1/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/9th/NetworkPractice1/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/9th/NetworkPractice1/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/practice/fundamentals/9th/NetworkPractice2/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/9th/NetworkPractice2/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.3"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 9
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/practice/fundamentals/9th/NetworkPractice2/build.gradle
+++ b/AndroidStudio/practice/fundamentals/9th/NetworkPractice2/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/practice/fundamentals/9th/NetworkPractice2/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/practice/fundamentals/9th/NetworkPractice2/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/10th/ContentProviderCallSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/10th/ContentProviderCallSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/10th/ContentProviderCallSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/10th/ContentProviderCallSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/10th/ContentProviderCallSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/10th/ContentProviderCallSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/10th/ContentProviderLoaderSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/10th/ContentProviderLoaderSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/10th/ContentProviderLoaderSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/10th/ContentProviderLoaderSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/10th/ContentProviderLoaderSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/10th/ContentProviderLoaderSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/10th/ContentProviderSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/10th/ContentProviderSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/10th/ContentProviderSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/10th/ContentProviderSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/10th/ContentProviderSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/10th/ContentProviderSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/10th/SQLiteSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/10th/SQLiteSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/10th/SQLiteSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/10th/SQLiteSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/10th/SQLiteSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/10th/SQLiteSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/10th/SimpleCursorAdapterSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/10th/SimpleCursorAdapterSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 16
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/10th/SimpleCursorAdapterSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/10th/SimpleCursorAdapterSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/10th/SimpleCursorAdapterSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/10th/SimpleCursorAdapterSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/1st/FrameLayoutSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/1st/FrameLayoutSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/1st/FrameLayoutSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/1st/FrameLayoutSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/1st/FrameLayoutSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/1st/FrameLayoutSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/1st/GravitySample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/1st/GravitySample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/1st/GravitySample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/1st/GravitySample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/1st/GravitySample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/1st/GravitySample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/1st/LayoutGravitySample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/1st/LayoutGravitySample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/1st/LayoutGravitySample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/1st/LayoutGravitySample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/1st/LayoutGravitySample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/1st/LayoutGravitySample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/1st/LayoutParamsSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/1st/LayoutParamsSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/1st/LayoutParamsSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/1st/LayoutParamsSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/1st/LayoutParamsSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/1st/LayoutParamsSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/1st/LinearLayoutSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/1st/LinearLayoutSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/1st/LinearLayoutSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/1st/LinearLayoutSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/1st/LinearLayoutSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/1st/LinearLayoutSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/1st/PaddingMarginSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/1st/PaddingMarginSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/1st/PaddingMarginSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/1st/PaddingMarginSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/1st/PaddingMarginSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/1st/PaddingMarginSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/1st/RelativeLayoutSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/1st/RelativeLayoutSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/1st/RelativeLayoutSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/1st/RelativeLayoutSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/1st/RelativeLayoutSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/1st/RelativeLayoutSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/1st/ScrollViewSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/1st/ScrollViewSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/1st/ScrollViewSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/1st/ScrollViewSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/1st/ScrollViewSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/1st/ScrollViewSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/2nd/ControllerSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/2nd/ControllerSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/2nd/ControllerSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/2nd/ControllerSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/2nd/ControllerSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/2nd/ControllerSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/3rd/AnimationResourceSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/3rd/AnimationResourceSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/3rd/AnimationResourceSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/3rd/AnimationResourceSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/3rd/AnimationResourceSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/3rd/AnimationResourceSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/3rd/ColorStateListResourceSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/3rd/ColorStateListResourceSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/3rd/ColorStateListResourceSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/3rd/ColorStateListResourceSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/3rd/ColorStateListResourceSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/3rd/ColorStateListResourceSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/3rd/DrawableResourceSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/3rd/DrawableResourceSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/3rd/DrawableResourceSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/3rd/DrawableResourceSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/3rd/DrawableResourceSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/3rd/DrawableResourceSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/3rd/MenuResourceSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/3rd/MenuResourceSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/3rd/MenuResourceSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/3rd/MenuResourceSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/3rd/MenuResourceSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/3rd/MenuResourceSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/3rd/StringResourceSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/3rd/StringResourceSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/3rd/StringResourceSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/3rd/StringResourceSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/3rd/StringResourceSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/3rd/StringResourceSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/3rd/StyleResourceSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/3rd/StyleResourceSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/3rd/StyleResourceSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/3rd/StyleResourceSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/3rd/StyleResourceSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/3rd/StyleResourceSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/3rd/ValueResourceSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/3rd/ValueResourceSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/3rd/ValueResourceSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/3rd/ValueResourceSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/3rd/ValueResourceSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/3rd/ValueResourceSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/4th/BroadcastReceiverSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/4th/BroadcastReceiverSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/4th/BroadcastReceiverSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/4th/BroadcastReceiverSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/4th/BroadcastReceiverSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/4th/BroadcastReceiverSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/4th/IntentSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/4th/IntentSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/4th/IntentSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/4th/IntentSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/4th/IntentSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/4th/IntentSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/4th/LocalBroadcastReceiverSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/4th/LocalBroadcastReceiverSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/4th/LocalBroadcastReceiverSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/4th/LocalBroadcastReceiverSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/4th/LocalBroadcastReceiverSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/4th/LocalBroadcastReceiverSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/4th/NotificationSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/4th/NotificationSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/4th/NotificationSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/4th/NotificationSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/4th/NotificationSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/4th/NotificationSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/4th/PendingIntentSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/4th/PendingIntentSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/4th/PendingIntentSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/4th/PendingIntentSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/4th/PendingIntentSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/4th/PendingIntentSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/5th/ActionBarSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/5th/ActionBarSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/5th/ActionBarSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/5th/ActionBarSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/5th/ActionBarSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/5th/ActionBarSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/5th/InteractionCallbackSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/5th/InteractionCallbackSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/5th/InteractionCallbackSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/5th/InteractionCallbackSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/5th/InteractionCallbackSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/5th/InteractionCallbackSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/5th/StyledActionBarSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/5th/StyledActionBarSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/5th/StyledActionBarSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/5th/StyledActionBarSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/5th/StyledActionBarSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/5th/StyledActionBarSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/6th/CustomListItemSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/6th/CustomListItemSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/6th/CustomListItemSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/6th/CustomListItemSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/6th/CustomListItemSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/6th/CustomListItemSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/6th/FragmentViewPagerSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/6th/FragmentViewPagerSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/6th/FragmentViewPagerSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/6th/FragmentViewPagerSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/6th/FragmentViewPagerSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/6th/FragmentViewPagerSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/6th/ListViewSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/6th/ListViewSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/6th/ListViewSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/6th/ListViewSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/6th/ListViewSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/6th/ListViewSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/6th/ViewPagerSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/6th/ViewPagerSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/6th/ViewPagerSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/6th/ViewPagerSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/6th/ViewPagerSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/6th/ViewPagerSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/7th/JsonObjectSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/7th/JsonObjectSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/7th/JsonObjectSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/7th/JsonObjectSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/7th/JsonObjectSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/7th/JsonObjectSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/7th/ParcelableSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/7th/ParcelableSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/7th/ParcelableSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/7th/ParcelableSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/7th/ParcelableSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/7th/ParcelableSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/8th/AsyncTaskSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/8th/AsyncTaskSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/8th/AsyncTaskSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/8th/AsyncTaskSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/8th/AsyncTaskSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/8th/AsyncTaskSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/8th/LoaderSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/8th/LoaderSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/8th/LoaderSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/8th/LoaderSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/8th/LoaderSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/8th/LoaderSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/AndroidStudio/projects/fundamentals/8th/ServiceSample/app/build.gradle
+++ b/AndroidStudio/projects/fundamentals/8th/ServiceSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -11,7 +11,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }

--- a/AndroidStudio/projects/fundamentals/8th/ServiceSample/build.gradle
+++ b/AndroidStudio/projects/fundamentals/8th/ServiceSample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 

--- a/AndroidStudio/projects/fundamentals/8th/ServiceSample/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidStudio/projects/fundamentals/8th/ServiceSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip


### PR DESCRIPTION
fix #48
- buildToolsVersion 19.0.3 -> 21.1.2
- runProguard -> minifyEnabled
- dependencies com.android.tools.build:gradle:0.9.+ -> com.android.tools.build:gradle:1.0.0
- gradle-1.10-all -> gradle-2.2.1-all