### PR TITLE
英語でzeroの場合の指定は無効なので削除

### DIFF
--- a/fundamentals/2.03.application-resource-management.md
+++ b/fundamentals/2.03.application-resource-management.md
@@ -340,14 +340,13 @@ public class MyActivity extends Activity {
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <plurals name="my_eggs">
-        <item quantity="zero">I have no egg.</item>
         <item quantity="one">I have one egg.</item>
         <item quantity="other">I have %d eggs.</item>
     </plurals>
 </resources>
 ```
 
-`<item>`要素の`quantity`属性には、`zero`、`one`、`two`、`few`、`many`、`other`の中から設定出来ます。
+`<item>`要素の`quantity`属性には、`zero`、`one`、`two`、`few`、`many`、`other`の中から設定出来ます。それぞれの言語の文法的特性によって、どの`quantity`属性を設定出来るか決まっています。
 
 Activity や Fragment など、Context を持っている所では、以下のように文字列を取り出します。
 


### PR DESCRIPTION
課題の回答作成中、教材を参考に `zero` の指定をしたところLintに警告されたので修正しました。
どうやら英語の文法的には `one` と `other` のみで表現は網羅されるようです（？）。（0の場合は I have 0 apples. で良い）

詳細: http://developer.android.com/guide/topics/resources/string-resource.html#Plurals

正しく理解できているか自信がないので、間違っていたらご指摘お願いします。