### PR TITLE
compileSdkVersionなどを一括管理できるように修正

### DIFF
--- a/AndroidStudio/assignments/advanced/3rd/DialogAssignment/app/build.gradle
+++ b/AndroidStudio/assignments/advanced/3rd/DialogAssignment/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.dialog"
-        minSdkVersion 8
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/10th/ContentProviderAssignment/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/10th/ContentProviderAssignment/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.contentprovider.beg"
-        minSdkVersion 8
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/10th/SQLiteAssignment/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/10th/SQLiteAssignment/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.sqlite.beg"
-        minSdkVersion 8
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/11th/TestAssignmentTarget/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/11th/TestAssignmentTarget/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.test.target"
-        minSdkVersion 8
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
 
         testApplicationId "jp.mixi.assignment.test.target.test"
         testInstrumentationRunner "android.test.InstrumentationTestRunner"
@@ -22,5 +22,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/1st/LayoutAssignment1/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/1st/LayoutAssignment1/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.layout.beg"
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/1st/LayoutAssignment2/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/1st/LayoutAssignment2/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.layout.med"
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/1st/LayoutAssignment3/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/1st/LayoutAssignment3/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.layout.adv"
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/2nd/ControllerAssignment1/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/2nd/ControllerAssignment1/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.controller.beg"
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/2nd/ControllerAssignment2/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/2nd/ControllerAssignment2/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.controller.med"
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/2nd/ControllerAssignment3/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/2nd/ControllerAssignment3/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.controller.adv"
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/2nd/ControllerAssignment4/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/2nd/ControllerAssignment4/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.controller.adv2"
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/3rd/DrawableResourceAssignment1/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/3rd/DrawableResourceAssignment1/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.res.drawable.beg"
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/3rd/StringResourceAssignment1/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/3rd/StringResourceAssignment1/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.res.string.beg"
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/4th/MessagingAndNotification/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/4th/MessagingAndNotification/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.messagingandnotification"
-        minSdkVersion 15
-        targetSdkVersion 21
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
         versionCode 1
         versionName "1.0"
     }
@@ -21,5 +21,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:21.0.3'
+    compile "com.android.support:appcompat-v7:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/5th/ActionBarAssignment1/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/5th/ActionBarAssignment1/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.actionbar.beg"
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/5th/ActionBarAssignment2/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/5th/ActionBarAssignment2/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.actionbar.med"
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/5th/InteractionCallbackAssignment1/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/5th/InteractionCallbackAssignment1/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.interaction.beg"
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/5th/InteractionCallbackAssignment2/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/5th/InteractionCallbackAssignment2/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.interaction.med"
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/6th/ListViewAssignment/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/6th/ListViewAssignment/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.listview.beg"
-        minSdkVersion 8
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/7th/SerializableAssignment/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/7th/SerializableAssignment/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.serializable.beg"
-        minSdkVersion 8
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/7th/SharedPreferencesAssignment/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/7th/SharedPreferencesAssignment/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.sharedpreferences.sharedpreferencesassignment"
-        minSdkVersion 8
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/8th/AsyncTaskAssignment1/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/8th/AsyncTaskAssignment1/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.async.beg"
-        minSdkVersion 8
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/fundamentals/9th/NetworkAssignment/app/build.gradle
+++ b/AndroidStudio/assignments/fundamentals/9th/NetworkAssignment/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.network.networkAssignment"
-        minSdkVersion 9
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/assignments/introductions/4th/ApkInstallationAssignment/app/build.gradle
+++ b/AndroidStudio/assignments/introductions/4th/ApkInstallationAssignment/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.assignment.install"
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile "com.android.support:appcompat-v7:${supportLibVersion}
 }

--- a/AndroidStudio/build.gradle
+++ b/AndroidStudio/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
     }
 }
 

--- a/AndroidStudio/build.gradle
+++ b/AndroidStudio/build.gradle
@@ -13,3 +13,11 @@ allprojects {
         jcenter()
     }
 }
+
+// 全体で共通で使うバージョンをパラメータ化
+ext {
+    androidSdkVersion = 23
+    androidMinSdkVersion = 7
+    androidBuildToolsVersion = "23.0.3"
+    supportLibVersion = "23.4.0"
+}

--- a/AndroidStudio/practice/advanced/1st/DebugPractice/app/build.gradle
+++ b/AndroidStudio/practice/advanced/1st/DebugPractice/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/advanced/1st/DebugPractice/app/build.gradle
+++ b/AndroidStudio/practice/advanced/1st/DebugPractice/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 8
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/advanced/3rd/DialogPractice/app/build.gradle
+++ b/AndroidStudio/practice/advanced/3rd/DialogPractice/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/advanced/3rd/DialogPractice/app/build.gradle
+++ b/AndroidStudio/practice/advanced/3rd/DialogPractice/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 8
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/advanced/3rd/DialogPractice2/app/build.gradle
+++ b/AndroidStudio/practice/advanced/3rd/DialogPractice2/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/advanced/3rd/DialogPractice2/app/build.gradle
+++ b/AndroidStudio/practice/advanced/3rd/DialogPractice2/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 8
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/advanced/3rd/IncludePractice/app/build.gradle
+++ b/AndroidStudio/practice/advanced/3rd/IncludePractice/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/advanced/3rd/IncludePractice/app/build.gradle
+++ b/AndroidStudio/practice/advanced/3rd/IncludePractice/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 8
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/advanced/3rd/PreferencePractice/app/build.gradle
+++ b/AndroidStudio/practice/advanced/3rd/PreferencePractice/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/advanced/3rd/PreferencePractice/app/build.gradle
+++ b/AndroidStudio/practice/advanced/3rd/PreferencePractice/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 8
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/10th/SQLitePractice/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/10th/SQLitePractice/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/fundamentals/10th/SQLitePractice/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/10th/SQLitePractice/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 8
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/1st/FrameLayoutPractice/Practice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/FrameLayoutPractice/Practice1/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/1st/FrameLayoutPractice/Practice2/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/FrameLayoutPractice/Practice2/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/1st/FrameLayoutPractice/Practice2/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/FrameLayoutPractice/Practice2/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/fundamentals/1st/LinearLayoutPractice/Practice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/LinearLayoutPractice/Practice1/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/1st/LinearLayoutPractice/Practice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/LinearLayoutPractice/Practice1/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/fundamentals/1st/LinearLayoutPractice/Practice2/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/LinearLayoutPractice/Practice2/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/1st/LinearLayoutPractice/Practice2/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/LinearLayoutPractice/Practice2/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/fundamentals/1st/RelativeLayoutPractice/Practice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/RelativeLayoutPractice/Practice1/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/1st/RelativeLayoutPractice/Practice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/RelativeLayoutPractice/Practice1/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/fundamentals/1st/RelativeLayoutPractice/Practice2/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/RelativeLayoutPractice/Practice2/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/1st/RelativeLayoutPractice/Practice2/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/RelativeLayoutPractice/Practice2/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/fundamentals/1st/ScrollViewPractice/Practice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/1st/ScrollViewPractice/Practice1/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'android'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/2nd/ActivityPractice/Practice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/2nd/ActivityPractice/Practice1/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/2nd/ActivityPractice/Practice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/2nd/ActivityPractice/Practice1/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/fundamentals/2nd/ActivityPractice/Practice2/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/2nd/ActivityPractice/Practice2/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/2nd/ActivityPractice/Practice2/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/2nd/ActivityPractice/Practice2/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/fundamentals/2nd/FragmentPractice/Practice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/2nd/FragmentPractice/Practice1/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/2nd/FragmentPractice/Practice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/2nd/FragmentPractice/Practice1/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/fundamentals/2nd/FragmentPractice/Practice2/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/2nd/FragmentPractice/Practice2/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/2nd/FragmentPractice/Practice2/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/2nd/FragmentPractice/Practice2/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/fundamentals/3rd/ResourceManagement/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/3rd/ResourceManagement/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.practice.resourcemanagement"
-        minSdkVersion 15
-        targetSdkVersion 21
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
         versionCode 1
         versionName "1.0"
     }
@@ -20,6 +20,5 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:21.0.3'
+    compile "com.android.support:appcompat-v7:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/4th/MessagingAndNotification/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/4th/MessagingAndNotification/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "jp.mixi.practice.messagingandnotification"
-        minSdkVersion 15
-        targetSdkVersion 21
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
         versionCode 1
         versionName "1.0"
     }
@@ -20,6 +20,5 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:21.0.3'
+    compile "com.android.support:appcompat-v7:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/5th/ActionBarPractice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/5th/ActionBarPractice1/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/5th/ActionBarPractice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/5th/ActionBarPractice1/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/fundamentals/5th/InteractionCallbackPractice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/5th/InteractionCallbackPractice1/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 7
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/5th/InteractionCallbackPractice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/5th/InteractionCallbackPractice1/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/fundamentals/6th/ListViewPractice/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/6th/ListViewPractice/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/fundamentals/6th/ListViewPractice/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/6th/ListViewPractice/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 8
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/7th/SerializablePractice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/7th/SerializablePractice1/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/fundamentals/7th/SerializablePractice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/7th/SerializablePractice1/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 8
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/7th/SharedPreferencesPractice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/7th/SharedPreferencesPractice1/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/fundamentals/7th/SharedPreferencesPractice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/7th/SharedPreferencesPractice1/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 8
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/7th/StoragePractice/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/7th/StoragePractice/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/fundamentals/7th/StoragePractice/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/7th/StoragePractice/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 8
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/9th/NetworkPractice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/9th/NetworkPractice1/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/fundamentals/9th/NetworkPractice1/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/9th/NetworkPractice1/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }

--- a/AndroidStudio/practice/fundamentals/9th/NetworkPractice2/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/9th/NetworkPractice2/app/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 17

--- a/AndroidStudio/practice/fundamentals/9th/NetworkPractice2/app/build.gradle
+++ b/AndroidStudio/practice/fundamentals/9th/NetworkPractice2/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 17
-    buildToolsVersion "21.1.2"
+    compileSdkVersion androidSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 17
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidSdkVersion
     }
 
     buildTypes {
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile "com.android.support:support-v4:${supportLibVersion}"
 }


### PR DESCRIPTION
android gradle pluginが一部古かったので更新
全プロジェクトのcompileSdkVersionなどを変更するのに全てを変えるのは辛いのでパラメータ化して一括管理できるように修正
- compileSdkVersion
- buildToolsVersion
- minSdkVersion
- targetSdkVersion
- サポートライブラリのバージョン