### PR TITLE
add gradle setting for training

### DIFF
--- a/AndroidStudio/settings.gradle
+++ b/AndroidStudio/settings.gradle
@@ -7,13 +7,18 @@ include ':1-1-RelativeLayoutPractice-Practice1'
 project(':1-1-RelativeLayoutPractice-Practice1').projectDir = new File('practice/fundamentals/1st/RelativeLayoutPractice/Practice1/app')
 include ':1-1-RelativeLayoutPractice-Practice2'
 project(':1-1-RelativeLayoutPractice-Practice2').projectDir = new File('practice/fundamentals/1st/RelativeLayoutPractice/Practice2/app')
+include ':1-1-FrameLayoutPractice-Practice1'
+project(':1-1-FrameLayoutPractice-Practice1').projectDir = new File('practice/fundamentals/1st/FrameLayoutPractice/Practice1/app')
+include ':1-1-FrameLayoutPractice-Practice2'
+project(':1-1-FrameLayoutPractice-Practice2').projectDir = new File('practice/fundamentals/1st/FrameLayoutPractice/Practice2/app')
+include ':1-1-ScrollViewPractice-Practice1'
+project(':1-1-ScrollViewPractice-Practice1').projectDir = new File('practice/fundamentals/1st/ScrollViewPractice/Practice1/app')
 include ':1-1-LayoutAssignment1'
 project(':1-1-LayoutAssignment1').projectDir = new File('assignments/fundamentals/1st/LayoutAssignment1/app')
 include ':1-1-LayoutAssignment2'
 project(':1-1-LayoutAssignment2').projectDir = new File('assignments/fundamentals/1st/LayoutAssignment2/app')
 include ':1-1-LayoutAssignment3'
 project(':1-1-LayoutAssignment3').projectDir = new File('assignments/fundamentals/1st/LayoutAssignment3/app')
-
 
 // fundamentals 2nd
 include ':1-2-ActivityPractice-Practice1'


### PR DESCRIPTION
AndroidStudio 2.2 Preview1 でトレーニングをやり始めましたが、

- 1-1-FrameLayoutPractice-Practice1
- 1-1-FrameLayoutPractice-Practice2
- 1-1-ScrollViewPractice-Practice1

の設定がsettings.gradleになく、Gradleプロジェクトとして認識してくれず、「Plugin with id ‘com.android.application’ not found.」と怒られました。この設定を入れて、更新するとうまく表示されたので、解決策としてPR送ります。ご確認ください。