### PR TITLE
bradleファイルのパス間違いを修正とPractice2の説明追加

### DIFF
--- a/fundamentals/2.02.activity-and-fragment.md
+++ b/fundamentals/2.02.activity-and-fragment.md
@@ -144,7 +144,7 @@ Fragment が Activity に組み込まれた状態です。<br />
 <pre>
 public class MainFragment extends Fragment {
     private FragmentCallbacks mCallback;
-
+	
     @Override
     public void onAttach(Activity activity) {
         super.onAttach(activity);
@@ -153,7 +153,7 @@ public class MainFragment extends Fragment {
             mCallback = (FragmentCallbacks) activity;
         } catch (ClassCastException e) {
             // Fragment が組み込まれる先の Activity に対して、FragmentCallbacks インタフェースの実装を要求する為
-            // キャストに失敗した場合は、実行時例外としてプログラムのミスであることを示す
+            // キャストに失敗した場合は、実行時例外としてプログラムのミスであることを示す 
             throw new IllegalStateException("activity should implement FragmentCallbacks", e);
         }
     }
@@ -578,7 +578,7 @@ Activity のインスタンスをどのようにスタック上で管理する�
     android:launchMode="singleTop"/>
 ```
 
-モード名 | 意味
+モード名 | 意味 
 -----|-----
 standard | デフォルトのモード。Activity の呼び出しごとに毎回インスタンスを生成する為、複数の同じActivityのインスタンスがスタック上に現れる。
 singleTop | Activity を呼び出した時、スタックの一番上にその Activity のインスタンスがあるときは、`Activity#onNewIntent()`を呼び出して、そこに新しい Intent を送りつける

--- a/fundamentals/2.02.activity-and-fragment.md
+++ b/fundamentals/2.02.activity-and-fragment.md
@@ -144,7 +144,7 @@ Fragment が Activity に組み込まれた状態です。<br />
 <pre>
 public class MainFragment extends Fragment {
     private FragmentCallbacks mCallback;
-	
+
     @Override
     public void onAttach(Activity activity) {
         super.onAttach(activity);
@@ -153,7 +153,7 @@ public class MainFragment extends Fragment {
             mCallback = (FragmentCallbacks) activity;
         } catch (ClassCastException e) {
             // Fragment が組み込まれる先の Activity に対して、FragmentCallbacks インタフェースの実装を要求する為
-            // キャストに失敗した場合は、実行時例外としてプログラムのミスであることを示す 
+            // キャストに失敗した場合は、実行時例外としてプログラムのミスであることを示す
             throw new IllegalStateException("activity should implement FragmentCallbacks", e);
         }
     }
@@ -578,7 +578,7 @@ Activity のインスタンスをどのようにスタック上で管理する�
     android:launchMode="singleTop"/>
 ```
 
-モード名 | 意味 
+モード名 | 意味
 -----|-----
 standard | デフォルトのモード。Activity の呼び出しごとに毎回インスタンスを生成する為、複数の同じActivityのインスタンスがスタック上に現れる。
 singleTop | Activity を呼び出した時、スタックの一番上にその Activity のインスタンスがあるときは、`Activity#onNewIntent()`を呼び出して、そこに新しい Intent を送りつける
@@ -595,14 +595,16 @@ singleInstance | タスクの中で、Activity のインスタンスは常に 1 
 #### Activity
 
 1. 新しい Activity と、それに対応するレイアウトを作成してください。  
-(使用するプロジェクト: AndroidStudio/practice/fundamentals/2nd/ActivityPractice/practice1/build.gradle)
+(使用するプロジェクト: AndroidStudio/practice/fundamentals/2nd/ActivityPractice/practice1/app/build.gradle)
 2. 1で作った Activity を、アプリ起動時に表示するよう変更してください。
+(変更先のプロジェクト: AndroidStudio/practice/fundamentals/2nd/ActivityPractice/practice2/app/build.gradle)
 
 #### Fragment
 
 1. 新しい Fragment と、それに対応するレイアウトを作成してください。  
-(使用するプロジェクト: AndroidStudio/practice/fundamentals/2nd/FragmentPractice/practice1/build.gradle)
+(使用するプロジェクト: AndroidStudio/practice/fundamentals/2nd/FragmentPractice/practice1/app/build.gradle)
 2. 1で作った Fragment を、既存の Activity に組み込んでください。
+(変更先のプロジェクト: AndroidStudio/practice/fundamentals/2nd/FragmentPractice/practice2/app/build.gradle)
 
 ### 課題
 


### PR DESCRIPTION
パスはGitHub上のパスを参考に修正しました。

説明追加については、Practice2フォルダがあったので「Practice2 プロジェクトに Practice1のレイアウトファイルをコピーしてやるんだよ」というのがわかると良いかなと思ったのでアイデアとして追記しています。自分は間違えてPractice1プロジェクトをいじってしまいました。