### PR TITLE
fix typo about how to use RelativeLayout

### DIFF
--- a/docs/fundamentals/2.01.create-layout.md
+++ b/docs/fundamentals/2.01.create-layout.md
@@ -521,7 +521,7 @@ LinearLayoutは個々の内部View（子View）に対して`android:layout_weigh
 1. ボタンAを`android:layout_centerHorizontal="true"`で横方向の中心に、さらに`android:layout_centerVertical="true"`で縦方向の中心に配置しています。また`android:id="@+id/a"`と宣言することでボタンAの識別子を付与しています。  
 2. ボタンBは`android:layout_toRightOf="@+id/a"`を指定することでボタンAの右に配置しており、`android:layout_alignTop="@+id/a"`で上端をボタンAの上端に合わせています。  
 3. ボタンCは`android:layout_below="@+id/b"`を指定することでボタンBの下に配置しており、`android:layout_alignLeft="@+id/b"`で左端をボタンBの左端に合わせるようにしています。  
-4. ボタンDは`android:layout_toRightOf="@+id/b"`を指定することでボタンBの右に配置しており、`android:layout_alignTop="@+id/b"`で上端をボタンBの上端、`android:layout_alignBottom="@+id/c"`で上端をボタンCの下端に配置するようにしています。  
+4. ボタンDは`android:layout_toRightOf="@+id/b"`を指定することでボタンBの右に配置しており、`android:layout_alignTop="@+id/b"`で上端をボタンBの上端、`android:layout_alignBottom="@+id/c"`で下端をボタンCの下端に配置するようにしています。  
   
 要素 | 意味
 --- | ---


### PR DESCRIPTION
## 概要

* こちらの教材を使用して勉強させて頂いている際に、typoではないかと思われる記述に気づいたのでPull Requestさせて頂きました。

<img width="328" alt="スクリーンショット 2019-05-19 10 54 47" src="https://user-images.githubusercontent.com/901084/57976978-67302600-7a28-11e9-8373-5c437b96e676.png">

* http://mixi-inc.github.io/AndroidTraining/fundamentals/2.01.create-layout.html

>ボタンDはandroid:layout_toRightOf="@+id/b"を指定することでボタンBの右に配置しており、android:layout_alignTop="@+id/b"で上端をボタンBの上端、android:layout_alignBottom="@+id/c"で上端をボタンCの下端に配置するようにしています。

意図から察すると、
`下端` をボタンCの下端に配置するようにしています。
とするのが正しいのではないかと思いました。

お手すきで、ご確認お願い 致します 🙇 

