### PR TITLE
fix typo about how to use FrameLayout

### DIFF
--- a/docs/fundamentals/2.01.create-layout.md
+++ b/docs/fundamentals/2.01.create-layout.md
@@ -575,7 +575,7 @@ FrameLayoutはViewを重ねて配置するのに使用します。
 </FrameLayout>
 ```
 `FrameLayout`内の上から順にViewが配置されます。  
-上記の場合は、赤の`ImageView`の上に青の`ImageView`が配置され、その上に緑の`ImageView`が配置されています。  
+上記の場合は、赤の`ImageView`の上に緑の`ImageView`が配置され、その上に青の`ImageView`が配置されています。  
 
 ### <a name="ScrollView" />ScrollView
 ScrollViewは画面にレイアウトが収まらない場合、収まらない分をスクロールして表示するための使用します。  


### PR DESCRIPTION
## 関連URL

* http://mixi-inc.github.io/AndroidTraining/fundamentals/2.01.create-layout.html

## 概要

* こちらの教材を使用して勉強させて頂いている際に、おそらく意図と異なるのではないかと思われる記述に気づいたのでPull Requestさせて頂きました。

![スクリーンショット 2019-06-02 14 46 43](https://user-images.githubusercontent.com/901084/58757352-ea339f00-8545-11e9-9082-aaf229efe652.png)

https://github.com/mixi-inc/AndroidTraining/pull/188/files#diff-924fda81c4ccf1173351c33977892d2dL578

お手すきで、ご確認お願い 致します 🙇 